### PR TITLE
Remove debug logging from the happy path

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -122,7 +122,6 @@ module.exports = {
     }
 
     let indexPath = path.dirname(path.resolve(index));
-    console.log(`path to the index file: ${indexPath}`);
     let html = generateIndex(index);
 
     // process metedata


### PR DESCRIPTION
https://github.com/tableflip/pdflippers is using `markdawn` to create headed "paper". I'd like to be able to pipe the html output straight to a file, or [hcat](https://github.com/kessler/node-hcat), but this log line is mixed in. See: https://github.com/tableflip/pdflippers/issues/4
